### PR TITLE
Core/Allied Races: Implemented the client packets for allied races.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -503,6 +503,10 @@ bool Player::Create(ObjectGuid::LowType guidlow, WorldPackets::Character::Charac
     else if (getClass() == CLASS_DEMON_HUNTER)
         start_level = sWorld->getIntConfig(CONFIG_START_DEMON_HUNTER_PLAYER_LEVEL);
 
+    // Set allied race starting level 
+    else if (getRace() >= RACE_NIGHTBORNE)
+        start_level = 20;
+
     if (createInfo->TemplateSet)
     {
         if (m_session->HasPermission(rbac::RBAC_PERM_USE_CHARACTER_TEMPLATES))

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -358,6 +358,7 @@ void WorldSession::HandleCharEnum(PreparedQueryResult result)
         WorldPackets::Character::EnumCharactersResult::RaceUnlock raceUnlock;
         raceUnlock.RaceID = requirement.first;
         raceUnlock.HasExpansion = GetAccountExpansion() >= requirement.second.Expansion;
+        raceUnlock.HasAchievement = requirement.second.AchievementId == 0;   /* Work around until account achievement are implemented */ 
         charEnum.RaceUnlockData.push_back(raceUnlock);
     }
 
@@ -987,7 +988,36 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
             else if (cEntry->CinematicSequenceID)
                 pCurrChar->SendCinematicStart(cEntry->CinematicSequenceID);
             else if (ChrRacesEntry const* rEntry = sChrRacesStore.LookupEntry(pCurrChar->getRace()))
-                pCurrChar->SendCinematicStart(rEntry->CinematicSequenceID);
+            {
+                if (rEntry->CinematicSequenceID)
+                    pCurrChar->SendCinematicStart(rEntry->CinematicSequenceID);
+                else
+                {
+                    switch (pCurrChar->getRace())
+                    {
+                    case RACE_HIGHMOUNTAIN_TAUREN:
+                        pCurrChar->GetSceneMgr().PlayScene(1901);
+                        break;
+                    case RACE_NIGHTBORNE:
+                        pCurrChar->GetSceneMgr().PlayScene(1900);
+                        break;
+                    case RACE_LIGHTFORGED_DRAENEI:
+                        pCurrChar->GetSceneMgr().PlayScene(1902);
+                        break;
+                    case RACE_VOID_ELF:
+                        pCurrChar->GetSceneMgr().PlayScene(1903);
+                        break;
+                    case RACE_DARK_IRON_DWARF:
+                        pCurrChar->GetSceneMgr().PlayScene(2137);
+                        break;
+                        /* case RACE_MAGHAR_ORC: Need the scene id for Maghar orcs 
+                            pCurrChar->GetSceneMgr().PlayScene(1903); <update scene before uncommenting this>
+                            break; */
+                    default:
+                        break;
+                    }
+                }
+            }
 
             // send new char string if not empty
             if (!sWorld->GetNewCharString().empty())


### PR DESCRIPTION
Still needs SQLs yet

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Set the start level of allied races to level 20 
-  Enable temporary workaround for needed achievements to unlock 
-  Enable Scenes for allied races

**please note I am not creator of the original code.. All Credit goes to Traesh and others who Enabled the allied races for Ashamane core 7.3.5**


**Target branch(es):** 
- [X] BFA Project Battle For Azeroth


**Issues addressed:** Closes #  (insert issue tracker number)
- [X] Packets sent to unlock allied races
- [X] Overcoming the lack of account bound achievements (Temporary Workaround)
**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Yes
- [ ] No

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Player create info is still needed 
- [ ] Darkiron Dwarfs and Mag'har create with no language learned 
- [ ] playercreate Spells / Pets Database info still needed


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
